### PR TITLE
Use batch-affine addition during buckets aggregation

### DIFF
--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -44,10 +44,10 @@ impl<G: CurveAffine> BucketAdder<G> {
             return;
         }
 
-        // batch addtition doesn't work with equal points
+        // batch addtition doesn't work if P = +-Q
         // so we need to perform this addition in place
-        // even though it is very slow because of into_affine
-        if self.buckets[bucket] == base {
+        // even though it is slow because of into_affine
+        if self.buckets[bucket].get_x() == base.get_x() {
             let mut p = self.buckets[bucket].into_projective();
             p.add_assign_mixed(&base);
             self.buckets[bucket] = p.into_affine();

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -78,10 +78,10 @@ impl<G: CurveAffine> BucketAdder<G> {
     }
     
     fn process_buffer(&mut self) {
-        let c = CurveAffine::batch_addition(&self.a[0..self.count], &self.b[0..self.count]);
+        CurveAffine::batch_addition(&self.a[0..self.count], &mut self.b[0..self.count]);
 
         for i in 0..self.count {
-            self.buckets[self.indexes[i]] = c[i];
+            self.buckets[self.indexes[i]] = self.b[i];
         }
 
         self.count = 0;

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -98,7 +98,7 @@ impl<G: CurveAffine> BucketAdder<G> {
         }
         self.batch_count = 0;
 
-        // reapply colisions
+        // reapply collisions
         let collisions_count = self.collisions_count;
         self.collisions_count = 0;
         for i in 0..collisions_count {

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -1,49 +1,49 @@
-use std::collections::HashSet;
-
 use pairing::{CurveAffine, CurveProjective,};
 
-const BATCH_SIZE: usize = 256;
+const BATCH_SIZE: usize = 1024;
+const MAX_COLLISIONS_COUNT: usize = 128;
 
 pub struct BucketAdder<G: CurveAffine> {
     buckets: Vec<G>,
     
     batch_lhs: Vec<G>,
     batch_rhs: Vec<G>,
-    scratch_space: Vec<G::Base>,
-    batch_indexes: Vec<usize>,
+    batch_buckets: Vec<usize>,
     batch_count: usize,
-    buckets_in_batch: HashSet<usize>,
+    
+    bucket_in_batch: Vec<bool>,
     collisions: Vec<(G, usize)>,
-    batch_size: usize,
+    collisions_count: usize,
+
+    scratch_space: Vec<G::Base>,
 }
 
 impl<G: CurveAffine> BucketAdder<G> {
     pub fn new(c: u32, _chunk: usize) -> BucketAdder<G> {
         let zero = G::zero();
-        let batch_size = BATCH_SIZE;
         BucketAdder { 
             buckets: vec![zero; (1 << c) - 1], 
-            batch_lhs: vec![zero; batch_size], 
-            batch_rhs: vec![zero; batch_size], 
-            scratch_space: vec![zero.get_x(); batch_size],
-            batch_indexes: vec![0; batch_size],
+            batch_lhs: vec![zero; BATCH_SIZE], 
+            batch_rhs: vec![zero; BATCH_SIZE], 
+            scratch_space: vec![zero.get_x(); BATCH_SIZE],
+            batch_buckets: vec![0; BATCH_SIZE],
             batch_count: 0,
-            buckets_in_batch: HashSet::new(),
-            collisions: Vec::new(),
-            batch_size,
+            bucket_in_batch: vec![false; (1 << c) - 1],
+            collisions: vec![(zero, 0); MAX_COLLISIONS_COUNT],
+            collisions_count: 0,
         }
     }
 
     pub fn add_to_bucket(&mut self, base: G, bucket: usize) {
         self.add(base, bucket);
 
-        if self.batch_count == self.batch_size || self.collisions.len() >= self.batch_size / 2  {
+        if self.batch_count == BATCH_SIZE || self.collisions_count >= MAX_COLLISIONS_COUNT  {
             self.process_batch();
         }
     }
 
     pub fn finalize(mut self) -> Vec<G> {
-        while !self.collisions.is_empty() {
+        while self.collisions_count > 0 {
             self.process_batch();
         }
         self.process_batch();
@@ -59,15 +59,16 @@ impl<G: CurveAffine> BucketAdder<G> {
             return
         }
         
-        // bucket is already in buffer, postpone that addition
-        if self.buckets_in_batch.contains(&bucket) {
-            self.collisions.push((base, bucket));
+        // bucket is already in batch, postpone that addition
+        if self.bucket_in_batch[bucket] {
+            self.collisions[self.collisions_count] = (base, bucket);
+            self.collisions_count += 1;
             return;
         }
 
         // batch addtition doesn't work if P = +-Q
         // so we need to perform this addition in place
-        // even though it is slow because of into_affine
+        // even though it is slow
         if self.buckets[bucket].get_x() == base.get_x() {
             let mut p = self.buckets[bucket].into_projective();
             p.add_assign_mixed(&base);
@@ -77,8 +78,8 @@ impl<G: CurveAffine> BucketAdder<G> {
 
         self.batch_lhs[self.batch_count] = self.buckets[bucket];
         self.batch_rhs[self.batch_count] = base;
-        self.batch_indexes[self.batch_count] = bucket;
-        self.buckets_in_batch.insert(bucket);
+        self.batch_buckets[self.batch_count] = bucket;
+        self.bucket_in_batch[bucket] = true;
         self.batch_count += 1;
     }
     
@@ -86,16 +87,18 @@ impl<G: CurveAffine> BucketAdder<G> {
         CurveAffine::batch_addition_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count], &mut self.scratch_space);
 
         for i in 0..self.batch_count {
-            self.buckets[self.batch_indexes[i]] = self.batch_lhs[i];
+            let bucket = self.batch_buckets[i];
+            self.buckets[bucket] = self.batch_lhs[i];
+            self.bucket_in_batch[bucket] = false;
         }
 
         self.batch_count = 0;
-        self.buckets_in_batch.clear();
 
-        let collisions = self.collisions.clone();
-        self.collisions.clear();
-        for (base, bucket) in collisions {
-            self.add(base, bucket)
+        let collisions_count = self.collisions_count;
+        self.collisions_count = 0;
+        for i in 0..collisions_count {
+            let collision = self.collisions[i];
+            self.add(collision.0, collision.1);
         }
     }
 }

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -2,31 +2,50 @@ use std::collections::HashSet;
 
 use pairing::{CurveAffine, CurveProjective,};
 
+const BATCH_SIZE: usize = 256;
+
 pub struct BucketAdder<G: CurveAffine> {
     buckets: Vec<G>,
-    a: Vec<G>,
-    b: Vec<G>,
-    indexes: Vec<usize>,
-    count: usize,
-    busy: HashSet<usize>,
+    
+    batch_lhs: Vec<G>,
+    batch_rhs: Vec<G>,
+    batch_indexes: Vec<usize>,
+    batch_count: usize,
+    buckets_in_batch: HashSet<usize>,
     collisions: Vec<(G, usize)>,
-    buffer_size: usize,
+    batch_size: usize,
 }
 
 impl<G: CurveAffine> BucketAdder<G> {
-    pub fn new(c: u32, chunk: usize) -> BucketAdder<G> {
+    pub fn new(c: u32, _chunk: usize) -> BucketAdder<G> {
         let zero = G::zero();
-        let buffer_size = 256;
+        let batch_size = BATCH_SIZE;
         BucketAdder { 
             buckets: vec![zero; (1 << c) - 1], 
-            a: vec![zero; buffer_size], 
-            b: vec![zero; buffer_size], 
-            indexes: vec![0; buffer_size],
-            count: 0,
-            busy: HashSet::new(),
+            batch_lhs: vec![zero; batch_size], 
+            batch_rhs: vec![zero; batch_size], 
+            batch_indexes: vec![0; batch_size],
+            batch_count: 0,
+            buckets_in_batch: HashSet::new(),
             collisions: Vec::new(),
-            buffer_size,
+            batch_size,
         }
+    }
+
+    pub fn add_to_bucket(&mut self, base: G, bucket: usize) {
+        self.add(base, bucket);
+
+        if self.batch_count == self.batch_size || self.collisions.len() >= self.batch_size / 2  {
+            self.process_batch();
+        }
+    }
+
+    pub fn finalize(mut self) -> Vec<G> {
+        while !self.collisions.is_empty() {
+            self.process_batch();
+        }
+        self.process_batch();
+        self.buckets
     }
 
     fn add(&mut self, base: G, bucket: usize) {
@@ -39,7 +58,7 @@ impl<G: CurveAffine> BucketAdder<G> {
         }
         
         // bucket is already in buffer, postpone that addition
-        if self.busy.contains(&bucket) {
+        if self.buckets_in_batch.contains(&bucket) {
             self.collisions.push((base, bucket));
             return;
         }
@@ -54,38 +73,22 @@ impl<G: CurveAffine> BucketAdder<G> {
             return;
         }
 
-        self.a[self.count] = self.buckets[bucket];
-        self.b[self.count] = base;
-        self.indexes[self.count] = bucket;
-        self.busy.insert(bucket);
-        self.count += 1;
-    }
-
-    pub fn add_to_bucket(&mut self, base: G, bucket: usize) {
-        self.add(base, bucket);
-
-        if self.count == self.buffer_size || self.collisions.len() >= self.buffer_size / 2  {
-            self.process_buffer();
-        }
-    }
-
-    pub fn finalize(mut self) -> Vec<G> {
-        while !self.collisions.is_empty() {
-            self.process_buffer();
-        }
-        self.process_buffer();
-        self.buckets
+        self.batch_lhs[self.batch_count] = self.buckets[bucket];
+        self.batch_rhs[self.batch_count] = base;
+        self.batch_indexes[self.batch_count] = bucket;
+        self.buckets_in_batch.insert(bucket);
+        self.batch_count += 1;
     }
     
-    fn process_buffer(&mut self) {
-        CurveAffine::batch_addition_assign(&mut self.a[0..self.count], &self.b[0..self.count]);
+    fn process_batch(&mut self) {
+        CurveAffine::batch_addition_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count]);
 
-        for i in 0..self.count {
-            self.buckets[self.indexes[i]] = self.a[i];
+        for i in 0..self.batch_count {
+            self.buckets[self.batch_indexes[i]] = self.batch_lhs[i];
         }
 
-        self.count = 0;
-        self.busy.clear();
+        self.batch_count = 0;
+        self.buckets_in_batch.clear();
 
         let collisions = self.collisions.clone();
         self.collisions.clear();

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -84,7 +84,7 @@ impl<G: CurveAffine> BucketAdder<G> {
     }
     
     fn process_batch(&mut self) {
-        CurveAffine::batch_addition_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count], &mut self.scratch_space);
+        CurveAffine::batch_add_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count], &mut self.scratch_space);
 
         for i in 0..self.batch_count {
             let bucket = self.batch_buckets[i];

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -1,0 +1,96 @@
+use std::collections::HashSet;
+
+use pairing::{CurveAffine, CurveProjective,};
+
+pub struct BucketAdder<G: CurveAffine> {
+    buckets: Vec<G>,
+    a: Vec<G>,
+    b: Vec<G>,
+    indexes: Vec<usize>,
+    count: usize,
+    busy: HashSet<usize>,
+    collisions: Vec<(G, usize)>,
+    buffer_size: usize,
+}
+
+impl<G: CurveAffine> BucketAdder<G> {
+    pub fn new(c: u32, chunk: usize) -> BucketAdder<G> {
+        let zero = G::zero();
+        let buffer_size = 256;
+        BucketAdder { 
+            buckets: vec![zero; (1 << c) - 1], 
+            a: vec![zero; buffer_size], 
+            b: vec![zero; buffer_size], 
+            indexes: vec![0; buffer_size],
+            count: 0,
+            busy: HashSet::new(),
+            collisions: Vec::new(),
+            buffer_size,
+        }
+    }
+
+    fn add(&mut self, base: G, bucket: usize) {
+        // perform "addition" in place
+        if self.buckets[bucket] == G::zero() {
+            self.buckets[bucket] = base;
+            return
+        } else if base == G::zero() {
+            return
+        }
+        
+        // bucket is already in buffer, postpone that addition
+        if self.busy.contains(&bucket) {
+            self.collisions.push((base, bucket));
+            return;
+        }
+
+        // batch addtition doesn't work with equal points
+        // so we need to perform this addition in place
+        // even though it is very slow because of into_affine
+        if self.buckets[bucket] == base {
+            let mut p = self.buckets[bucket].into_projective();
+            p.add_assign_mixed(&base);
+            self.buckets[bucket] = p.into_affine();
+            return;
+        }
+
+        self.a[self.count] = self.buckets[bucket];
+        self.b[self.count] = base;
+        self.indexes[self.count] = bucket;
+        self.busy.insert(bucket);
+        self.count += 1;
+    }
+
+    pub fn add_to_bucket(&mut self, base: G, bucket: usize) {
+        self.add(base, bucket);
+
+        if self.count == self.buffer_size || self.collisions.len() >= self.buffer_size / 2  {
+            self.process_buffer();
+        }
+    }
+
+    pub fn finalize(mut self) -> Vec<G> {
+        while !self.collisions.is_empty() {
+            self.process_buffer();
+        }
+        self.process_buffer();
+        self.buckets
+    }
+    
+    fn process_buffer(&mut self) {
+        let c = CurveAffine::batch_addition(&self.a[0..self.count], &self.b[0..self.count]);
+
+        for i in 0..self.count {
+            self.buckets[self.indexes[i]] = c[i];
+        }
+
+        self.count = 0;
+        self.busy.clear();
+
+        let collisions = self.collisions.clone();
+        self.collisions.clear();
+        for (base, bucket) in collisions {
+            self.add(base, bucket)
+        }
+    }
+}

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -9,6 +9,7 @@ pub struct BucketAdder<G: CurveAffine> {
     
     batch_lhs: Vec<G>,
     batch_rhs: Vec<G>,
+    scratch_space: Vec<G::Base>,
     batch_indexes: Vec<usize>,
     batch_count: usize,
     buckets_in_batch: HashSet<usize>,
@@ -24,6 +25,7 @@ impl<G: CurveAffine> BucketAdder<G> {
             buckets: vec![zero; (1 << c) - 1], 
             batch_lhs: vec![zero; batch_size], 
             batch_rhs: vec![zero; batch_size], 
+            scratch_space: vec![zero.get_x(); batch_size],
             batch_indexes: vec![0; batch_size],
             batch_count: 0,
             buckets_in_batch: HashSet::new(),
@@ -81,7 +83,7 @@ impl<G: CurveAffine> BucketAdder<G> {
     }
     
     fn process_batch(&mut self) {
-        CurveAffine::batch_addition_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count]);
+        CurveAffine::batch_addition_assign(&mut self.batch_lhs[0..self.batch_count], &self.batch_rhs[0..self.batch_count], &mut self.scratch_space);
 
         for i in 0..self.batch_count {
             self.buckets[self.batch_indexes[i]] = self.batch_lhs[i];

--- a/bellman/src/batch_addition.rs
+++ b/bellman/src/batch_addition.rs
@@ -78,10 +78,10 @@ impl<G: CurveAffine> BucketAdder<G> {
     }
     
     fn process_buffer(&mut self) {
-        CurveAffine::batch_addition(&self.a[0..self.count], &mut self.b[0..self.count]);
+        CurveAffine::batch_addition_assign(&mut self.a[0..self.count], &self.b[0..self.count]);
 
         for i in 0..self.count {
-            self.buckets[self.indexes[i]] = self.b[i];
+            self.buckets[self.indexes[i]] = self.a[i];
         }
 
         self.count = 0;

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -22,6 +22,7 @@ pub mod sonic;
 mod group;
 mod source;
 mod multiexp;
+mod batch_addition;
 
 #[cfg(test)]
 mod tests;

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -240,17 +240,23 @@ fn test_speed_with_bn256() {
 
     println!("Started");
     
-    let start = std::time::Instant::now();
+    let mut results = vec![];
+    let iter_count = 100;
+    for _ in 0..iter_count {
+        let g = g.clone();
+        let v = v.clone();
+        let start = std::time::Instant::now();
+        let _fast = multiexp(
+            &pool,
+            (g, 0),
+            FullDensity,
+            v
+        ).wait().unwrap();
+        let duration_ns = start.elapsed().as_nanos() as f64;
+        results.push(duration_ns);
+    }
 
-    let _fast = multiexp(
-        &pool,
-        (g, 0),
-        FullDensity,
-        v
-    ).wait().unwrap();
-
-
-    let duration_ns = start.elapsed().as_nanos() as f64;
+    let duration_ns: f64 = results.into_iter().sum::<f64>() / iter_count as f64;
     println!("Elapsed {} ns for {} samples", duration_ns, SAMPLES);
     let time_per_sample = duration_ns/(SAMPLES as f64);
     println!("Tested on {} samples on {} CPUs with {} ns per multiplication", SAMPLES, cpus, time_per_sample);

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -1,3 +1,4 @@
+use crate::batch_addition::BucketAdder;
 use crate::pairing::{
     CurveAffine,
     CurveProjective,
@@ -49,7 +50,7 @@ fn multiexp_inner<Q, D, G, S>(
         let mut bases = bases.new();
 
         // Create space for the buckets
-        let mut buckets = vec![G::Projective::zero(); (1 << c) - 1];
+        let mut buckets = BucketAdder::new(c, chunk);
 
         // only the first round uses this
         let handle_trivial = chunk == 0;
@@ -80,7 +81,7 @@ fn multiexp_inner<Q, D, G, S>(
                     let exp = exp.as_ref()[0] % (1 << c);
 
                     if exp != 0 {
-                        bases.add_assign_mixed(&mut buckets[(exp - 1) as usize])?;
+                        buckets.add_to_bucket(bases.next().unwrap(), (exp - 1) as usize);
                     } else {
                         bases.skip(1)?;
                     }
@@ -93,8 +94,8 @@ fn multiexp_inner<Q, D, G, S>(
         //                    (a) + b +
         //                    ((a) + b) + c
         let mut running_sum = G::Projective::zero();
-        for exp in buckets.into_iter().rev() {
-            running_sum.add_assign(&exp);
+        for exp in buckets.finalize().into_iter().rev() {
+            running_sum.add_assign_mixed(&exp);
             acc.add_assign(&running_sum);
         }
 
@@ -198,13 +199,38 @@ fn test_with_bls12() {
 }
 
 #[test]
+fn test_with_bn256() {
+    use rand::{self, Rand};
+    use crate::pairing::bn256::Bn256;
+
+    const SAMPLES: usize = 1;
+
+    let rng = &mut rand::thread_rng();
+    let v = Arc::new((0..SAMPLES).map(|_| <Bn256 as ScalarEngine>::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
+    let g = Arc::new((0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>());
+
+    let naive = naive_multiexp(g.clone(), v.clone());
+
+    let pool = Worker::new();
+
+    let fast = multiexp(
+        &pool,
+        (g, 0),
+        FullDensity,
+        v
+    ).wait().unwrap();
+
+    assert_eq!(naive, fast);
+}
+
+#[test]
 fn test_speed_with_bn256() {
     use rand::{self, Rand};
     use crate::pairing::bn256::Bn256;
     use num_cpus;
 
     let cpus = num_cpus::get();
-    const SAMPLES: usize = 1 << 22;
+    const SAMPLES: usize = 1 << 18;
 
     let rng = &mut rand::thread_rng();
     let v = Arc::new((0..SAMPLES).map(|_| <Bn256 as ScalarEngine>::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
@@ -212,6 +238,8 @@ fn test_speed_with_bn256() {
 
     let pool = Worker::new();
 
+    println!("Started");
+    
     let start = std::time::Instant::now();
 
     let _fast = multiexp(

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -81,7 +81,7 @@ fn multiexp_inner<Q, D, G, S>(
                     let exp = exp.as_ref()[0] % (1 << c);
 
                     if exp != 0 {
-                        buckets.add_to_bucket(bases.next().unwrap(), (exp - 1) as usize);
+                        buckets.add_to_bucket(bases.next()?, (exp - 1) as usize);
                     } else {
                         bases.skip(1)?;
                     }

--- a/bellman/src/source.rs
+++ b/bellman/src/source.rs
@@ -32,7 +32,8 @@ pub trait Source<G: CurveAffine> {
     /// Skips `amt` elements from the source, avoiding deserialization.
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError>;
 
-    fn next(&mut self) -> Option<G>;
+    /// Returns the element from the source. Fails if the point is at infinity.
+    fn next(&mut self) -> Result<G, SynthesisError>;
 }
 
 impl<G: CurveAffine> SourceBuilder<G> for (Arc<Vec<G>>, usize) {
@@ -70,10 +71,18 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
         Ok(())
     }
 
-    fn next(&mut self) -> Option<G> {
-        let b = self.0.get(self.1)?;
+    fn next(&mut self) -> Result<G, SynthesisError> {
+        if self.0.len() <= self.1 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "expected more bases when adding from source").into());
+        }
+
+        if self.0[self.1].is_zero() {
+            return Err(SynthesisError::UnexpectedIdentity)
+        }
+        
+        let p = self.0[self.1];
         self.1 += 1;
-        Some(*b)
+        Ok(p)
     }
 }
 

--- a/bellman/src/source.rs
+++ b/bellman/src/source.rs
@@ -32,7 +32,7 @@ pub trait Source<G: CurveAffine> {
     /// Skips `amt` elements from the source, avoiding deserialization.
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError>;
 
-    /// Returns the element from the source. Fails if the point is at infinity.
+    /// Returns the next element from the source. Fails if the point is at infinity.
     fn next(&mut self) -> Result<G, SynthesisError>;
 }
 

--- a/bellman/src/source.rs
+++ b/bellman/src/source.rs
@@ -31,6 +31,8 @@ pub trait Source<G: CurveAffine> {
 
     /// Skips `amt` elements from the source, avoiding deserialization.
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError>;
+
+    fn next(&mut self) -> Option<G>;
 }
 
 impl<G: CurveAffine> SourceBuilder<G> for (Arc<Vec<G>>, usize) {
@@ -66,6 +68,12 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
         self.1 += amt;
 
         Ok(())
+    }
+
+    fn next(&mut self) -> Option<G> {
+        let b = self.0.get(self.1)?;
+        self.1 += 1;
+        Some(*b)
     }
 }
 

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -486,11 +486,11 @@ impl CurveAffine for Fr {
         *self
     }
 
-    fn batch_addition(a: &[Self], b: &mut [Self]) {
+    fn batch_addition_assign(a: &mut [Self], b: &[Self]) {
         for i in 0..a.len() {
             let mut c = a[i].into_projective();
             c.add_assign_mixed(&b[i]);
-            b[i] = c;
+            a[i] = c;
         }
     }
 }

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -490,11 +490,11 @@ impl CurveAffine for Fr {
         unimplemented!()
     }
 
-    fn batch_addition_assign(a: &mut [Self], b: &[Self]) {
-        for i in 0..a.len() {
-            let mut c = a[i].into_projective();
-            c.add_assign_mixed(&b[i]);
-            a[i] = c;
+    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], _scratch_space: &mut [Self::Base]) {
+        for i in 0..lhs.len() {
+            let mut c = lhs[i].into_projective();
+            c.add_assign_mixed(&rhs[i]);
+            lhs[i] = c;
         }
     }
 }

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -490,7 +490,7 @@ impl CurveAffine for Fr {
         unimplemented!()
     }
 
-    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], _scratch_space: &mut [Self::Base]) {
+    fn batch_add_assign(lhs: &mut [Self], rhs: &[Self], _scratch_space: &mut [Self::Base]) {
         for i in 0..lhs.len() {
             let mut c = lhs[i].into_projective();
             c.add_assign_mixed(&rhs[i]);

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -485,4 +485,14 @@ impl CurveAffine for Fr {
     fn into_projective(&self) -> Self::Projective {
         *self
     }
+
+    fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self> {
+        let mut result = vec![];
+        for (a, b) in a.iter().zip(b.iter()) {
+            let mut c = a.into_projective();
+            c.add_assign_mixed(b);
+            result.push(c);
+        }
+        result
+    }
 }

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -487,7 +487,7 @@ impl CurveAffine for Fr {
     }
 
     fn get_x(&self) -> Self::Base {
-        unimplemented!()
+        *self
     }
 
     fn batch_add_assign(lhs: &mut [Self], rhs: &[Self], _scratch_space: &mut [Self::Base]) {

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -486,6 +486,10 @@ impl CurveAffine for Fr {
         *self
     }
 
+    fn get_x(&self) -> Self::Base {
+        unimplemented!()
+    }
+
     fn batch_addition_assign(a: &mut [Self], b: &[Self]) {
         for i in 0..a.len() {
             let mut c = a[i].into_projective();

--- a/bellman/src/tests/dummy_engine.rs
+++ b/bellman/src/tests/dummy_engine.rs
@@ -486,13 +486,11 @@ impl CurveAffine for Fr {
         *self
     }
 
-    fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self> {
-        let mut result = vec![];
-        for (a, b) in a.iter().zip(b.iter()) {
-            let mut c = a.into_projective();
-            c.add_assign_mixed(b);
-            result.push(c);
+    fn batch_addition(a: &[Self], b: &mut [Self]) {
+        for i in 0..a.len() {
+            let mut c = a[i].into_projective();
+            c.add_assign_mixed(&b[i]);
+            b[i] = c;
         }
-        result
     }
 }

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -20,13 +20,14 @@ fn test_batch_addition_bn256() {
     let rng = &mut rand::thread_rng();
     let mut a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
     let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut scratch_space = vec![a[0].get_x(); SAMPLES];
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition_assign(&mut a, &b);
+    CurveAffine::batch_addition_assign(&mut a, &b, &mut scratch_space);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
@@ -40,13 +41,14 @@ fn test_batch_addition_bls12() {
     let rng = &mut rand::thread_rng();
     let mut a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
     let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut scratch_space = vec![a[0].get_x(); SAMPLES];
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition_assign(&mut a, &b);
+    CurveAffine::batch_addition_assign(&mut a, &b, &mut scratch_space);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -18,19 +18,19 @@ fn test_batch_addition_bn256() {
     const SAMPLES: usize = 1 << 8;
 
     let rng = &mut rand::thread_rng();
-    let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
-    let mut b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition(&a, &mut b);
+    CurveAffine::batch_addition_assign(&mut a, &b);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
-    assert!(naive == b);
+    assert!(naive == a);
 }
 
 #[test]
@@ -38,17 +38,17 @@ fn test_batch_addition_bls12() {
     const SAMPLES: usize = 1 << 8;
 
     let rng = &mut rand::thread_rng();
-    let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
-    let mut b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition(&a, &mut b);
+    CurveAffine::batch_addition_assign(&mut a, &b);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
-    assert!(naive == b);
+    assert!(naive == a);
 }

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -19,18 +19,18 @@ fn test_batch_addition_bn256() {
 
     let rng = &mut rand::thread_rng();
     let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
-    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    let batch = CurveAffine::batch_addition(&a, &b);
+    CurveAffine::batch_addition(&a, &mut b);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
-    assert!(naive == batch);
+    assert!(naive == b);
 }
 
 #[test]
@@ -39,16 +39,16 @@ fn test_batch_addition_bls12() {
 
     let rng = &mut rand::thread_rng();
     let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
-    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
 
     let n = Instant::now();
     let naive = naive(a.clone(), b.clone());
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    let batch = CurveAffine::batch_addition(&a, &b);
+    CurveAffine::batch_addition(&a, &mut b);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
-    assert!(naive == batch);
+    assert!(naive == b);
 }

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use pairing::{bn256::{Fq, Bn256}, CurveAffine, ff::Field, Engine, CurveProjective, bls12_381::Bls12};
+use pairing::{bn256::{Bn256}, CurveAffine, Engine, CurveProjective, bls12_381::Bls12};
 use rand::{self, Rand};
 
 fn naive<G: CurveAffine>(a: Vec<G>, b: Vec<G>) -> Vec<G::Projective> {
@@ -39,8 +39,8 @@ fn test_batch_addition_bls12() {
     const SAMPLES: usize = 1 << 8;
 
     let rng = &mut rand::thread_rng();
-    let mut a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
-    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let mut a = (0..SAMPLES).map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let b = (0..SAMPLES).map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
     let mut scratch_space = vec![a[0].get_x(); SAMPLES];
 
     let n = Instant::now();

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -27,7 +27,7 @@ fn test_batch_addition_bn256() {
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition_assign(&mut a, &b, &mut scratch_space);
+    CurveAffine::batch_add_assign(&mut a, &b, &mut scratch_space);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
@@ -48,7 +48,7 @@ fn test_batch_addition_bls12() {
     println!("Naive: {}", n.elapsed().as_nanos());
 
     let ba = Instant::now();
-    CurveAffine::batch_addition_assign(&mut a, &b, &mut scratch_space);
+    CurveAffine::batch_add_assign(&mut a, &b, &mut scratch_space);
     println!("Batch: {}", ba.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();

--- a/bellman/tests/batch_addition.rs
+++ b/bellman/tests/batch_addition.rs
@@ -1,0 +1,54 @@
+use std::time::Instant;
+
+use pairing::{bn256::{Fq, Bn256}, CurveAffine, ff::Field, Engine, CurveProjective, bls12_381::Bls12};
+use rand::{self, Rand};
+
+fn naive<G: CurveAffine>(a: Vec<G>, b: Vec<G>) -> Vec<G::Projective> {
+    let mut result = vec![];
+    for (a, b) in a.iter().zip(b.iter()) {
+        let mut c = a.into_projective();
+        c.add_assign_mixed(b);
+        result.push(c);
+    }
+    result
+}
+
+#[test]
+fn test_batch_addition_bn256() {
+    const SAMPLES: usize = 1 << 8;
+
+    let rng = &mut rand::thread_rng();
+    let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+
+    let n = Instant::now();
+    let naive = naive(a.clone(), b.clone());
+    println!("Naive: {}", n.elapsed().as_nanos());
+
+    let ba = Instant::now();
+    let batch = CurveAffine::batch_addition(&a, &b);
+    println!("Batch: {}", ba.elapsed().as_nanos());
+    
+    let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
+    assert!(naive == batch);
+}
+
+#[test]
+fn test_batch_addition_bls12() {
+    const SAMPLES: usize = 1 << 8;
+
+    let rng = &mut rand::thread_rng();
+    let a = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+    let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
+
+    let n = Instant::now();
+    let naive = naive(a.clone(), b.clone());
+    println!("Naive: {}", n.elapsed().as_nanos());
+
+    let ba = Instant::now();
+    let batch = CurveAffine::batch_addition(&a, &b);
+    println!("Batch: {}", ba.elapsed().as_nanos());
+    
+    let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
+    assert!(naive == batch);
+}

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -198,10 +198,8 @@ macro_rules! curve_impl {
                 self.x
             }
 
-            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]) {
-                let zero = Self::Base::zero();
+            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]) {
                 let num_points = lhs.len();
-                let mut scratch_space = vec![zero; num_points];
 
                 let mut batch_inversion_accumulator = Self::Base::one();
                 for i in 0..num_points {

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -194,7 +194,7 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
-            fn batch_addition(lhs: &[Self], rhs: &mut [Self]) {
+            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]) {
                 let zero = Self::Base::zero();
                 let num_points = lhs.len();
                 let mut scratch_space = vec![zero; num_points];
@@ -202,37 +202,37 @@ macro_rules! curve_impl {
                 let mut batch_inversion_accumulator = Self::Base::one();
                 for i in 0..num_points {
                     // x2 + x1
-                    scratch_space[i] = lhs[i].x;  
-                    scratch_space[i].add_assign(&rhs[i].x);
+                    scratch_space[i] = rhs[i].x;  
+                    scratch_space[i].add_assign(&lhs[i].x);
 
                     // x2 - x1
-                    rhs[i].x.sub_assign(&lhs[i].x);
+                    lhs[i].x.sub_assign(&rhs[i].x);
 
                     // y2 - y1
-                    rhs[i].y.sub_assign(&lhs[i].y);
+                    lhs[i].y.sub_assign(&rhs[i].y);
 
                     // (y2 - y1)*accumulator_old
-                    rhs[i].y.mul_assign(&batch_inversion_accumulator);
+                    lhs[i].y.mul_assign(&batch_inversion_accumulator);
 
-                    batch_inversion_accumulator.mul_assign(&rhs[i].x)
+                    batch_inversion_accumulator.mul_assign(&lhs[i].x)
                 }
                 batch_inversion_accumulator = batch_inversion_accumulator.inverse().unwrap();
 
                 for i in (0..num_points).rev() {
-                    rhs[i].y.mul_assign(&batch_inversion_accumulator); // update accumulator
-                    batch_inversion_accumulator.mul_assign(&rhs[i].x);
+                    lhs[i].y.mul_assign(&batch_inversion_accumulator); // update accumulator
+                    batch_inversion_accumulator.mul_assign(&lhs[i].x);
                     
                     // x3 = lambda_squared - x2 - x1
-                    rhs[i].x = rhs[i].y;
-                    rhs[i].x.square();
-                    rhs[i].x.sub_assign(&scratch_space[i]); 
+                    lhs[i].x = lhs[i].y;
+                    lhs[i].x.square();
+                    lhs[i].x.sub_assign(&scratch_space[i]); 
 
-                    scratch_space[i] = lhs[i].x;
-                    scratch_space[i].sub_assign(&rhs[i].x);
-                    scratch_space[i].mul_assign(&rhs[i].y);
+                    scratch_space[i] = rhs[i].x;
+                    scratch_space[i].sub_assign(&lhs[i].x);
+                    scratch_space[i].mul_assign(&lhs[i].y);
 
-                    rhs[i].y = scratch_space[i];
-                    rhs[i].y.sub_assign(&lhs[i].y);
+                    lhs[i].y = scratch_space[i];
+                    lhs[i].y.sub_assign(&rhs[i].y);
                 }
             }
         }

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -194,6 +194,10 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
+            fn get_x(&self) -> Self::Base {
+                self.x
+            }
+
             fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]) {
                 let zero = Self::Base::zero();
                 let num_points = lhs.len();

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -194,6 +194,65 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
+            fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self> {
+                let n = a.len();
+                let zero = Self::Base::zero();
+
+                let mut lambdas = vec![zero; n];
+                let mut denom = Self::Base::one();
+                let mut ls = vec![zero; n];
+                for i in 0..n {
+                    let a = a[i];
+                    let b = b[i];
+                    // lambda = b.x - a.x
+                    let mut lambda = b.x;
+                    lambda.sub_assign(&a.x);
+
+                    lambdas[i] = lambda;
+                    ls[i] = denom;
+                    denom.mul_assign(&lambda);
+                }
+                denom = denom.inverse().unwrap();
+                
+                let mut rs = vec![zero; n];
+                let mut r = denom;
+                for i in 0..n {
+                    rs[n - 1 - i] = r;
+                    r.mul_assign(&lambdas[n - 1 - i]);
+                }
+
+                let mut result = vec![Self::zero(); n];
+                for i in 0..n {
+                    let a = a[i];
+                    let b = b[i];
+                    
+                    // l[i] * r[i] * denom
+                    let mut d = rs[i];
+                    d.mul_assign(&ls[i]);
+                    //d.mul_assign(&rs[i]);
+
+                    // (b.y - a.y) * d
+                    let mut k = b.y;
+                    k.sub_assign(&a.y);
+                    k.mul_assign(&d);
+
+                    // k^2 - a.x - b.x
+                    let mut x = k;
+                    x.mul_assign(&k);
+                    x.sub_assign(&a.x);
+                    x.sub_assign(&b.x);
+
+                    // k*(a.x - x) - a.y
+                    let mut y = a.x;
+                    y.sub_assign(&x);
+                    y.mul_assign(&k);
+                    y.sub_assign(&a.y);
+
+                    result[i] = Self {x, y, infinity: false};
+                }
+
+                result
+            }
         }
 
         impl Rand for $projective {

--- a/pairing/src/bn256/ec.rs
+++ b/pairing/src/bn256/ec.rs
@@ -203,6 +203,10 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
+            fn get_x(&self) -> Self::Base {
+                self.x
+            }
+
             fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]) {
                 let zero = Self::Base::zero();
                 let num_points = lhs.len();

--- a/pairing/src/bn256/ec.rs
+++ b/pairing/src/bn256/ec.rs
@@ -207,22 +207,22 @@ macro_rules! curve_impl {
                 self.x
             }
 
-            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]) {
+            fn batch_add_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]) {
                 let num_points = lhs.len();
 
                 let mut batch_inversion_accumulator = Self::Base::one();
                 for i in 0..num_points {
-                    // x2 + x1
+                    // r.x + l.x
                     scratch_space[i] = rhs[i].x;  
                     scratch_space[i].add_assign(&lhs[i].x);
 
-                    // x2 - x1
+                    // l.x - r.x = lambda_i
                     lhs[i].x.sub_assign(&rhs[i].x);
 
-                    // y2 - y1
+                    // l.y - r.y
                     lhs[i].y.sub_assign(&rhs[i].y);
 
-                    // (y2 - y1)*accumulator_old
+                    // (l.y - r.y) * Li
                     lhs[i].y.mul_assign(&batch_inversion_accumulator);
 
                     batch_inversion_accumulator.mul_assign(&lhs[i].x)
@@ -230,18 +230,22 @@ macro_rules! curve_impl {
                 batch_inversion_accumulator = batch_inversion_accumulator.inverse().unwrap();
 
                 for i in (0..num_points).rev() {
-                    lhs[i].y.mul_assign(&batch_inversion_accumulator); // update accumulator
+                    // k = (l.y - r.y) * Li * (lambda_inv * Ri)
+                    lhs[i].y.mul_assign(&batch_inversion_accumulator);
+                    // (lambda_inv * Ri)
                     batch_inversion_accumulator.mul_assign(&lhs[i].x);
                     
-                    // x3 = lambda_squared - x2 - x1
+                    // x = k^2 - l.x - r.x
                     lhs[i].x = lhs[i].y;
                     lhs[i].x.square();
                     lhs[i].x.sub_assign(&scratch_space[i]); 
 
+                    // (r.x - x) * k
                     scratch_space[i] = rhs[i].x;
                     scratch_space[i].sub_assign(&lhs[i].x);
                     scratch_space[i].mul_assign(&lhs[i].y);
 
+                    // y = (r.x - x) * k - r.y
                     lhs[i].y = scratch_space[i];
                     lhs[i].y.sub_assign(&rhs[i].y);
                 }

--- a/pairing/src/bn256/ec.rs
+++ b/pairing/src/bn256/ec.rs
@@ -203,64 +203,46 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
-            fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self> {
-                let n = a.len();
+            fn batch_addition(lhs: &[Self], rhs: &mut [Self]) {
                 let zero = Self::Base::zero();
+                let num_points = lhs.len();
+                let mut scratch_space = vec![zero; num_points];
 
-                let mut lambdas = vec![zero; n];
-                let mut denom = Self::Base::one();
-                let mut ls = vec![zero; n];
-                for i in 0..n {
-                    let a = a[i];
-                    let b = b[i];
-                    // lambda = b.x - a.x
-                    let mut lambda = b.x;
-                    lambda.sub_assign(&a.x);
+                let mut batch_inversion_accumulator = Self::Base::one();
+                for i in 0..num_points {
+                    // x2 + x1
+                    scratch_space[i] = lhs[i].x;  
+                    scratch_space[i].add_assign(&rhs[i].x);
 
-                    lambdas[i] = lambda;
-                    ls[i] = denom;
-                    denom.mul_assign(&lambda);
+                    // x2 - x1
+                    rhs[i].x.sub_assign(&lhs[i].x);
+
+                    // y2 - y1
+                    rhs[i].y.sub_assign(&lhs[i].y);
+
+                    // (y2 - y1)*accumulator_old
+                    rhs[i].y.mul_assign(&batch_inversion_accumulator);
+
+                    batch_inversion_accumulator.mul_assign(&rhs[i].x)
                 }
-                denom = denom.inverse().unwrap();
-                
-                let mut rs = vec![zero; n];
-                let mut r = denom;
-                for i in 0..n {
-                    rs[n - 1 - i] = r;
-                    r.mul_assign(&lambdas[n - 1 - i]);
-                }
+                batch_inversion_accumulator = batch_inversion_accumulator.inverse().unwrap();
 
-                let mut result = vec![Self::zero(); n];
-                for i in 0..n {
-                    let a = a[i];
-                    let b = b[i];
+                for i in (0..num_points).rev() {
+                    rhs[i].y.mul_assign(&batch_inversion_accumulator); // update accumulator
+                    batch_inversion_accumulator.mul_assign(&rhs[i].x);
                     
-                    // l[i] * r[i] * denom
-                    let mut d = rs[i];
-                    d.mul_assign(&ls[i]);
-                    //d.mul_assign(&rs[i]);
+                    // x3 = lambda_squared - x2 - x1
+                    rhs[i].x = rhs[i].y;
+                    rhs[i].x.square();
+                    rhs[i].x.sub_assign(&scratch_space[i]); 
 
-                    // (b.y - a.y) * d
-                    let mut k = b.y;
-                    k.sub_assign(&a.y);
-                    k.mul_assign(&d);
+                    scratch_space[i] = lhs[i].x;
+                    scratch_space[i].sub_assign(&rhs[i].x);
+                    scratch_space[i].mul_assign(&rhs[i].y);
 
-                    // k^2 - a.x - b.x
-                    let mut x = k;
-                    x.mul_assign(&k);
-                    x.sub_assign(&a.x);
-                    x.sub_assign(&b.x);
-
-                    // k*(a.x - x) - a.y
-                    let mut y = a.x;
-                    y.sub_assign(&x);
-                    y.mul_assign(&k);
-                    y.sub_assign(&a.y);
-
-                    result[i] = Self {x, y, infinity: false};
+                    rhs[i].y = scratch_space[i];
+                    rhs[i].y.sub_assign(&lhs[i].y);
                 }
-
-                result
             }
         }
         // impl Rand for $projective {

--- a/pairing/src/bn256/ec.rs
+++ b/pairing/src/bn256/ec.rs
@@ -207,10 +207,8 @@ macro_rules! curve_impl {
                 self.x
             }
 
-            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]) {
-                let zero = Self::Base::zero();
+            fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]) {
                 let num_points = lhs.len();
-                let mut scratch_space = vec![zero; num_points];
 
                 let mut batch_inversion_accumulator = Self::Base::one();
                 for i in 0..num_points {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -235,6 +235,8 @@ pub trait CurveAffine:
     // Performs batch affine addition and writes result in lhs
     // For all i: lhs[i] and rhs[i] strictly assumed to be not equal and not equal to zero
     fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]);
+
+    fn get_x(&self) -> Self::Base;
 }
 
 pub trait RawEncodable: CurveAffine {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -232,12 +232,12 @@ pub trait CurveAffine:
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
 
-    // Performs batch affine addition and writes result in lhs
-    // For all i: lhs[i] and rhs[i] strictly assumed to be not equal and not equal to zero
-    // scratch_space is a preallocated buffer with size equal to size of lhs and rhs
-    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]);
+    /// Performs batch affine addition and writes result in lhs. 
+    /// For all i: lhs[[i]] and rhs[[i]] strictly assumed to be not equal and not equal to zero. 
+    /// scratch_space is a preallocated buffer with size equal to sizes of lhs and rhs
+    fn batch_add_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]);
 
-    // Returns x coordinate of affine point
+    /// Returns x coordinate of affine point
     fn get_x(&self) -> Self::Base;
 }
 

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -231,6 +231,8 @@ pub trait CurveAffine:
     fn into_uncompressed(&self) -> Self::Uncompressed {
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
+
+    fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self>;
 }
 
 pub trait RawEncodable: CurveAffine {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -234,8 +234,10 @@ pub trait CurveAffine:
 
     // Performs batch affine addition and writes result in lhs
     // For all i: lhs[i] and rhs[i] strictly assumed to be not equal and not equal to zero
-    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]);
+    // scratch_space is a preallocated buffer with size equal to size of lhs and rhs
+    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self], scratch_space: &mut [Self::Base]);
 
+    // Returns x coordinate of affine point
     fn get_x(&self) -> Self::Base;
 }
 

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -232,7 +232,7 @@ pub trait CurveAffine:
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
 
-    fn batch_addition(a: &[Self], b: &[Self]) -> Vec<Self>;
+    fn batch_addition(lhs: &[Self], rhs: &mut [Self]);
 }
 
 pub trait RawEncodable: CurveAffine {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -232,7 +232,9 @@ pub trait CurveAffine:
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
 
-    fn batch_addition(lhs: &[Self], rhs: &mut [Self]);
+    // Performs batch affine addition and writes result in lhs
+    // For all i: lhs[i] and rhs[i] strictly assumed to be not equal and not equal to zero
+    fn batch_addition_assign(lhs: &mut [Self], rhs: &[Self]);
 }
 
 pub trait RawEncodable: CurveAffine {

--- a/pairing/tests/batch_addition.rs
+++ b/pairing/tests/batch_addition.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use pairing::{bn256::{Bn256}, CurveAffine, Engine, CurveProjective, bls12_381::Bls12};
+use fawkes_crypto_pairing_ce::{CurveAffine, bn256::Bn256, Engine, CurveProjective, bls12_381::Bls12};
 use rand::{self, Rand};
 
 fn naive<G: CurveAffine>(a: Vec<G>, b: Vec<G>) -> Vec<G::Projective> {
@@ -22,13 +22,13 @@ fn test_batch_addition_bn256() {
     let b = (0..SAMPLES).map(|_| <Bn256 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
     let mut scratch_space = vec![a[0].get_x(); SAMPLES];
 
-    let n = Instant::now();
+    let naive_timer = Instant::now();
     let naive = naive(a.clone(), b.clone());
-    println!("Naive: {}", n.elapsed().as_nanos());
+    println!("Naive: {}", naive_timer.elapsed().as_nanos());
 
-    let ba = Instant::now();
+    let batch_timer = Instant::now();
     CurveAffine::batch_add_assign(&mut a, &b, &mut scratch_space);
-    println!("Batch: {}", ba.elapsed().as_nanos());
+    println!("Batch: {}", batch_timer.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
     assert!(naive == a);
@@ -43,13 +43,13 @@ fn test_batch_addition_bls12() {
     let b = (0..SAMPLES).map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
     let mut scratch_space = vec![a[0].get_x(); SAMPLES];
 
-    let n = Instant::now();
+    let naive_timer = Instant::now();
     let naive = naive(a.clone(), b.clone());
-    println!("Naive: {}", n.elapsed().as_nanos());
+    println!("Naive: {}", naive_timer.elapsed().as_nanos());
 
-    let ba = Instant::now();
+    let batch_timer = Instant::now();
     CurveAffine::batch_add_assign(&mut a, &b, &mut scratch_space);
-    println!("Batch: {}", ba.elapsed().as_nanos());
+    println!("Batch: {}", batch_timer.elapsed().as_nanos());
     
     let naive: Vec<_> = naive.into_iter().map(|p| p.into_affine()).collect();
     assert!(naive == a);


### PR DESCRIPTION
This PR is aiming at improving the MSM performance. It has been achieved by implementing batch-affine addition on the buckets aggregation step of the Pippenger Algorithm.

There are two main parts of this PR:
1. Implementation of batch-affine addition (CurveAffine::batch_add_assign).
_Description of batch-affine addition:_ https://allfi.gitbook.io/zk-notes/cryptography/primitives/elliptic-curves/batch-affine-addition
_Reference implementation:_ https://github.com/AztecProtocol/barretenberg/blob/3b365807c55c386fd39aa54f66f7d06bc8727993/cpp/src/barretenberg/ecc/groups/element_impl.hpp#L698
2. Implementation of BucketAdder.
_Description of Pippenger Algorithm_: https://allfi.gitbook.io/zk-notes/cryptography/primitives/elliptic-curves/pippenger-algorithm
_Idea of the implementation_: https://github.com/z-prize/2022-entries/tree/main/open-division/prize4-msm-wasm/yrrid

> We do not do any preprocessing or sorting of the scalars, instead, we use a simple bit array to determine if a bucket is already the target of a point addition. In the event of a collision, we add the point and bucket pair to a linked list for later processing. When we have processed 1024 unique buckets, or reached 128 collisions, we do the batch invert and second phase of the point adds. We repeat this process until all the scalars have been processed.

The code here looks a bit awkward but all my attempts to improve readability led to performance degradation. So if anyone has any suggestions I would be grateful.

**Results:**
* i7-10750H, BN256: MSM duration was reduced from ~2100 ns per multiplication to ~1450 ns per multiplication (~31 %)
* i7-10750H: Proving time in wasm was reduced from ~18.5 s to 15 s (~19%)
* iPhone 11: Proving time in wasm was reduced from ~51 s to 35.5 s (~30%)
* M1: Proving time in wasm was reduced from 8.3-9 s to 7.3-7.5 s (~12-17%)
